### PR TITLE
Trim spaces around values by default.

### DIFF
--- a/options.go
+++ b/options.go
@@ -39,6 +39,7 @@ func (o *options) copy() *options {
 		prefix:            o.prefix,
 		isLoadFromFile:    o.isLoadFromFile,
 		defaultFileSuffix: o.defaultFileSuffix,
+		trimSpaces:        o.trimSpaces,
 	}
 }
 


### PR DESCRIPTION
Fix coping options.